### PR TITLE
fix: create zoneStorage from live-component

### DIFF
--- a/src/Admin/Adapters/Controller/Symfony/Controller/ZoneStorage/CreateZoneStorage/CreateZoneStorageController.php
+++ b/src/Admin/Adapters/Controller/Symfony/Controller/ZoneStorage/CreateZoneStorage/CreateZoneStorageController.php
@@ -43,7 +43,10 @@ final class CreateZoneStorageController extends AbstractController
             return $this->redirectToRoute('admin_configure');
         }
 
-        $form = $this->createForm(ZoneStorageType::class);
+        $form = $this->createForm(ZoneStorageType::class, new CreateZoneStorageDto(), [
+            'action' => $this->generateUrl('admin_zone_storages_create'),
+            'attr' => ['data-turbo-frame' => '_top'],
+        ]);
 
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/Shared/Tests/Entities/VO/PackagingTest.php
+++ b/src/Shared/Tests/Entities/VO/PackagingTest.php
@@ -24,23 +24,6 @@ use Shared\Entities\VO\Packaging;
 final class PackagingTest extends TestCase
 {
     /**
-     * @dataProvider provideDistributeTheSubdivisionCases
-     *
-     * @param array{array{Unit, float}, array{Unit, float}|null, array{Unit, float}|null} $packaging
-     * @param array{array{Unit, float}, array{Unit, float}|null, array{Unit, float}|null} $expected
-     */
-    public function testDistributeTheSubdivision(array $packaging, array $expected): void
-    {
-        // Arrange && Act
-        $packages = Packaging::fromArray($packaging);
-
-        // Assert
-        self::assertEquals($expected[0], $packages->parcel());
-        self::assertEquals($expected[1], $packages->subPackage());
-        self::assertEquals($expected[2], $packages->consumerUnit());
-    }
-
-    /**
      * @return iterable<string, array<array<int, array{Unit, float}|null>>>
      */
     public static function provideDistributeTheSubdivisionCases(): iterable
@@ -87,5 +70,22 @@ final class PackagingTest extends TestCase
             'packaging' => [[$unitDataBuilder->create('Colis', 'cls')->build(), 1.0], null, null],
             'expected' => [[$unitDataBuilder->create('Colis', 'cls')->build(), 1.0], null, null],
         ];
+    }
+
+    /**
+     * @dataProvider provideDistributeTheSubdivisionCases
+     *
+     * @param array{array{Unit, float}, array{Unit, float}|null, array{Unit, float}|null} $packaging
+     * @param array{array{Unit, float}, array{Unit, float}|null, array{Unit, float}|null} $expected
+     */
+    public function testDistributeTheSubdivision(array $packaging, array $expected): void
+    {
+        // Arrange && Act
+        $packages = Packaging::fromArray($packaging);
+
+        // Assert
+        self::assertEquals($expected[0], $packages->parcel());
+        self::assertEquals($expected[1], $packages->subPackage());
+        self::assertEquals($expected[2], $packages->consumerUnit());
     }
 }


### PR DESCRIPTION
When create entity from index page via create component, the entity does not created. 

ie zoneStorage create from component.

Close #87 