### PR TITLE
feat(auth): 227 add Auth BC infrastructure and User domain entity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,6 +97,7 @@
             "App\\": "src",
             "Shared\\": "src/Shared",
             "Admin\\": "src/Admin",
+            "Auth\\": "src/Auth",
             "Inventory\\": "src/Inventory"
         }
     },
@@ -104,6 +105,7 @@
         "psr-4": {
             "App\\Tests\\": "tests/",
             "Admin\\Tests\\": "src/Admin/Tests/",
+            "Auth\\Tests\\": "src/Auth/Tests/",
             "Shared\\Tests\\": "src/Shared/Tests/",
             "Inventory\\Tests\\": "src/Inventory/Tests/"
         }

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -5,3 +5,4 @@ imports:
     - src/Shared/Frameworks/deptrac.yaml
     - src/Admin/Frameworks/deptrac.yaml
     - src/Inventory/Frameworks/deptrac.yaml
+    - src/Auth/Frameworks/deptrac.yaml

--- a/src/Auth/Adapters/Gateway/ORM/Repository/DoctrineUserRepository.php
+++ b/src/Auth/Adapters/Gateway/ORM/Repository/DoctrineUserRepository.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Tests package.
+ *
+ * (c) Dev-Int Création <info@developpement-interessant.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Auth\Adapters\Gateway\ORM\Repository;
+
+use Auth\Entities\Repository\UserRepository;
+use Auth\Entities\User;
+use Auth\Tests\DataBuilder\UserDataBuilder;
+use Shared\Entities\ResourceUuid;
+use Shared\Entities\VO\EmailField;
+
+/**
+ * Stub implementation - ORM integration in issue #228.
+ *
+ * @see https://github.com/Dev-Int/tests/issues/228
+ */
+final class DoctrineUserRepository implements UserRepository
+{
+    public function getByUuid(ResourceUuid $uuid): User
+    {
+        // Stub: return fake user
+        return UserDataBuilder::aUser()->build();
+    }
+
+    public function getByEmail(EmailField $email): User
+    {
+        // Stub: return fake user
+        return UserDataBuilder::aUser()->build();
+    }
+
+    public function emailExists(EmailField $email): bool
+    {
+        // Stub: minimal implementation
+        return true;
+    }
+
+    public function create(User $user): void
+    {
+        // To implement with Doctrine...
+    }
+
+    public function update(User $user): void
+    {
+        // To implement with Doctrine...
+    }
+
+    public function delete(User $user): void
+    {
+        // To implement with Doctrine...
+    }
+}

--- a/src/Auth/Entities/Exception/InvalidHashedPassword.php
+++ b/src/Auth/Entities/Exception/InvalidHashedPassword.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Tests package.
+ *
+ * (c) Dev-Int Création <info@developpement-interessant.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Auth\Entities\Exception;
+
+use Shared\Entities\Exception\DomainException;
+
+final class InvalidHashedPassword extends DomainException
+{
+    public const string MESSAGE = 'Invalid hashed password format.';
+
+    public function __construct()
+    {
+        parent::__construct(self::MESSAGE, DomainException::INVALID_ARGUMENT_CODE);
+    }
+}

--- a/src/Auth/Entities/Exception/UserNotFound.php
+++ b/src/Auth/Entities/Exception/UserNotFound.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Tests package.
+ *
+ * (c) Dev-Int Création <info@developpement-interessant.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Auth\Entities\Exception;
+
+use Shared\Entities\Exception\DomainException;
+use Shared\Entities\Exception\ExceptionSerializableTrait;
+use Shared\Entities\ResourceUuid;
+
+final class UserNotFound extends DomainException implements \JsonSerializable
+{
+    use ExceptionSerializableTrait;
+
+    public const string MESSAGE = 'User not found.';
+
+    public function __construct(private readonly ResourceUuid $userUuid)
+    {
+        parent::__construct(self::MESSAGE, DomainException::NOT_FOUND_CODE);
+    }
+
+    /**
+     * @return iterable<string, array<int, string>|int|string>
+     */
+    public function jsonSerialize(): iterable
+    {
+        return $this->toJson() + [
+            'userUuid' => $this->userUuid->toString(),
+        ];
+    }
+}

--- a/src/Auth/Entities/Repository/UserRepository.php
+++ b/src/Auth/Entities/Repository/UserRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Tests package.
+ *
+ * (c) Dev-Int Création <info@developpement-interessant.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Auth\Entities\Repository;
+
+use Auth\Entities\Exception\UserNotFound;
+use Auth\Entities\User;
+use Shared\Entities\ResourceUuid;
+use Shared\Entities\VO\EmailField;
+
+interface UserRepository
+{
+    /**
+     * @throws UserNotFound
+     */
+    public function getByUuid(ResourceUuid $uuid): User;
+
+    /**
+     * @throws UserNotFound
+     */
+    public function getByEmail(EmailField $email): User;
+
+    public function emailExists(EmailField $email): bool;
+
+    public function create(User $user): void;
+
+    public function update(User $user): void;
+
+    public function delete(User $user): void;
+}

--- a/src/Auth/Entities/Role.php
+++ b/src/Auth/Entities/Role.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Tests package.
+ *
+ * (c) Dev-Int Création <info@developpement-interessant.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Auth\Entities;
+
+enum Role: string
+{
+    case USER = 'ROLE_USER';
+    case ADMIN = 'ROLE_ADMIN';
+    case INVENTORY_MANAGER = 'ROLE_INVENTORY_MANAGER';
+}

--- a/src/Auth/Entities/User.php
+++ b/src/Auth/Entities/User.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Tests package.
+ *
+ * (c) Dev-Int Création <info@developpement-interessant.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Auth\Entities;
+
+use Auth\Entities\VO\HashedPassword;
+use Shared\Entities\Clock\ClockFactory;
+use Shared\Entities\ResourceUuid;
+use Shared\Entities\VO\EmailField;
+
+final class User
+{
+    private const Role DEFAULT_ROLE = Role::USER;
+
+    /**
+     * @param array<Role> $roles
+     */
+    public static function create(
+        ResourceUuid $uuid,
+        EmailField $email,
+        HashedPassword $password,
+        array $roles = [],
+    ): self {
+        $roles = self::normalizeRoles($roles);
+
+        return new self(
+            uuid: $uuid,
+            email: $email,
+            password: $password,
+            roles: $roles,
+            createdAt: ClockFactory::clock()->now(),
+            updatedAt: ClockFactory::clock()->now(),
+        );
+    }
+
+    /**
+     * @param array<Role> $roles
+     */
+    public static function reconstitute(
+        ResourceUuid $uuid,
+        EmailField $email,
+        HashedPassword $password,
+        array $roles,
+        \DateTimeImmutable $createdAt,
+        \DateTimeImmutable $updatedAt,
+    ): self {
+        return new self(
+            uuid: $uuid,
+            email: $email,
+            password: $password,
+            roles: self::normalizeRoles($roles),
+            createdAt: $createdAt,
+            updatedAt: $updatedAt,
+        );
+    }
+
+    /**
+     * @param array<Role> $roles
+     */
+    private function __construct(
+        private readonly ResourceUuid $uuid,
+        private EmailField $email,
+        private HashedPassword $password,
+        private array $roles,
+        private readonly \DateTimeImmutable $createdAt,
+        private \DateTimeImmutable $updatedAt,
+    ) {
+    }
+
+    public function uuid(): ResourceUuid
+    {
+        return $this->uuid;
+    }
+
+    public function email(): EmailField
+    {
+        return $this->email;
+    }
+
+    public function password(): HashedPassword
+    {
+        return $this->password;
+    }
+
+    /**
+     * @return array<Role>
+     */
+    public function roles(): array
+    {
+        return $this->roles;
+    }
+
+    public function createdAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function updatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function hasRole(Role $role): bool
+    {
+        return \in_array($role, $this->roles, true);
+    }
+
+    public function isAdmin(): bool
+    {
+        return $this->hasRole(Role::ADMIN);
+    }
+
+    public function changeEmail(EmailField $newEmail): void
+    {
+        $this->email = $newEmail;
+        $this->updatedAt = ClockFactory::clock()->now();
+    }
+
+    public function changePassword(HashedPassword $newPassword): void
+    {
+        $this->password = $newPassword;
+        $this->updatedAt = ClockFactory::clock()->now();
+    }
+
+    /**
+     * @param array<Role> $roles
+     */
+    public function updateRoles(array $roles): void
+    {
+        $this->roles = self::normalizeRoles($roles);
+        $this->updatedAt = ClockFactory::clock()->now();
+    }
+
+    /**
+     * Ensures ROLE_USER is always present and roles are unique.
+     *
+     * @param array<Role> $roles
+     *
+     * @return array<Role>
+     */
+    private static function normalizeRoles(array $roles): array
+    {
+        $roles[] = self::DEFAULT_ROLE;
+
+        // Use enum value as a key to ensure uniqueness
+        $unique = [];
+        foreach ($roles as $role) {
+            $unique[$role->value] = $role;
+        }
+
+        return array_values($unique);
+    }
+}

--- a/src/Auth/Entities/VO/HashedPassword.php
+++ b/src/Auth/Entities/VO/HashedPassword.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Tests package.
+ *
+ * (c) Dev-Int Création <info@developpement-interessant.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Auth\Entities\VO;
+
+use Auth\Entities\Exception\InvalidHashedPassword;
+
+/**
+ * Value Object encapsulating a hashed password.
+ *
+ * This VO stores the already-hashed password string.
+ * Hashing is done in the adapter layer (Symfony PasswordHasher).
+ */
+final readonly class HashedPassword
+{
+    /**
+     * Regex pattern for valid hash algorithms.
+     * - bcrypt: $2y$, $2a$, $2b$
+     * - argon2i/argon2id: $argon2i$, $argon2id$
+     * - scrypt: $scrypt$.
+     */
+    private const string HASH_PATTERN = '/^\$(2[ayb]|argon2i(d)?|scrypt)\$/';
+
+    public static function fromHash(string $hash): self
+    {
+        return new self($hash);
+    }
+
+    private function __construct(private string $hash)
+    {
+        if ($hash === '' || preg_match(self::HASH_PATTERN, $hash) !== 1) {
+            throw new InvalidHashedPassword();
+        }
+    }
+
+    public function toString(): string
+    {
+        return $this->hash;
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->hash === $other->hash;
+    }
+}

--- a/src/Auth/Frameworks/config/services.php
+++ b/src/Auth/Frameworks/config/services.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Tests package.
+ *
+ * (c) Dev-Int Création <info@developpement-interessant.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $configurator): void {
+    $services = $configurator->services();
+
+    $services->defaults()
+        ->autowire()
+        ->autoconfigure()
+        ->private()
+    ;
+
+    $services->load(namespace: 'Auth\\', resource: __DIR__ . '/../../../Auth')
+        ->exclude(__DIR__ . '/../../../Auth/{Frameworks,Entities,Tests}')
+    ;
+
+    $services->load(
+        namespace: 'Auth\Entities\Repository\\',
+        resource: __DIR__ . '/../../../Auth/Entities/Repository'
+    );
+};

--- a/src/Auth/Frameworks/deptrac.yaml
+++ b/src/Auth/Frameworks/deptrac.yaml
@@ -1,0 +1,33 @@
+deptrac:
+    layers:
+        - name: Auth\Entities
+          collectors:
+              - type: classNameRegex
+                value: '#Auth\\Entities\\.*#'
+        - name: Auth\UseCases
+          collectors:
+              - type: classNameRegex
+                value: '#Auth\\UseCases\\.*#'
+        - name: Auth\Adapters
+          collectors:
+              - type: classNameRegex
+                value: '#Auth\\Adapters\\.*#'
+        - name: Auth\Contracts
+          collectors:
+              - type: classNameRegex
+                value: '#Auth\\Contracts\\.*#'
+    ruleset:
+        Auth\Entities:
+            - Shared\Entities
+        Auth\UseCases:
+            - Auth\Entities
+            - Shared\Entities
+        Auth\Adapters:
+            - Auth\Entities
+            - Auth\UseCases
+            - Auth\Contracts
+            - Shared\Entities
+            - Shared\Adapters
+        Auth\Contracts:
+            - Shared\Entities
+    skip_violations: []

--- a/src/Auth/Tests/DataBuilder/UserDataBuilder.php
+++ b/src/Auth/Tests/DataBuilder/UserDataBuilder.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Tests package.
+ *
+ * (c) Dev-Int Création <info@developpement-interessant.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Auth\Tests\DataBuilder;
+
+use Auth\Entities\Role;
+use Auth\Entities\User;
+use Auth\Entities\VO\HashedPassword;
+use Shared\Entities\Clock\ClockFactory;
+use Shared\Entities\ResourceUuid;
+use Shared\Entities\VO\EmailField;
+
+final class UserDataBuilder
+{
+    private ResourceUuid $uuid;
+    private EmailField $email;
+    private HashedPassword $password;
+
+    /** @var array<Role> */
+    private array $roles = [Role::USER];
+    private \DateTimeImmutable $createdAt;
+    private \DateTimeImmutable $updatedAt;
+
+    public static function aUser(): self
+    {
+        return new self();
+    }
+
+    private function __construct()
+    {
+        $this->uuid = ResourceUuid::generate();
+        $this->email = EmailField::fromString('user@example.com');
+        $this->password = HashedPassword::fromHash('$2y$13$hashedpassword');
+        $now = ClockFactory::clock()->now();
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function withUuid(ResourceUuid $uuid): self
+    {
+        $this->uuid = $uuid;
+
+        return $this;
+    }
+
+    public function withEmail(string $email): self
+    {
+        $this->email = EmailField::fromString($email);
+
+        return $this;
+    }
+
+    public function withPassword(string $hashedPassword): self
+    {
+        $this->password = HashedPassword::fromHash($hashedPassword);
+
+        return $this;
+    }
+
+    /**
+     * @param array<Role> $roles
+     */
+    public function withRoles(array $roles): self
+    {
+        $this->roles = $roles;
+
+        return $this;
+    }
+
+    public function asAdmin(): self
+    {
+        $this->roles = [Role::ADMIN, Role::USER];
+
+        return $this;
+    }
+
+    public function asInventoryManager(): self
+    {
+        $this->roles = [Role::INVENTORY_MANAGER, Role::USER];
+
+        return $this;
+    }
+
+    public function withCreatedAt(\DateTimeImmutable $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function withUpdatedAt(\DateTimeImmutable $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function build(): User
+    {
+        return User::reconstitute(
+            uuid: $this->uuid,
+            email: $this->email,
+            password: $this->password,
+            roles: $this->roles,
+            createdAt: $this->createdAt,
+            updatedAt: $this->updatedAt,
+        );
+    }
+}

--- a/src/Auth/Tests/Entities/UserTest.php
+++ b/src/Auth/Tests/Entities/UserTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Tests package.
+ *
+ * (c) Dev-Int Création <info@developpement-interessant.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Auth\Tests\Entities;
+
+use Auth\Entities\Role;
+use Auth\Entities\User;
+use Auth\Entities\VO\HashedPassword;
+use Auth\Tests\DataBuilder\UserDataBuilder;
+use PHPUnit\Framework\TestCase;
+use Shared\Entities\Clock\ClockFactory;
+use Shared\Entities\Clock\FrozenClock;
+use Shared\Entities\ResourceUuid;
+use Shared\Entities\VO\EmailField;
+
+/**
+ * @group unitTest
+ *
+ * @covers \Auth\Entities\User
+ */
+final class UserTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        ClockFactory::initialize(new FrozenClock(new \DateTimeImmutable('2025-01-15 10:00:00')));
+    }
+
+    public function testCreateUserWithDefaultRole(): void
+    {
+        // Arrange
+        $uuid = ResourceUuid::generate();
+        $email = EmailField::fromString('test@example.com');
+        $password = HashedPassword::fromHash('$2y$13$hashedpassword');
+
+        // Act
+        $user = User::create($uuid, $email, $password);
+
+        // Assert
+        self::assertSame($uuid->toString(), $user->uuid()->toString());
+        self::assertSame('test@example.com', $user->email()->toString());
+        self::assertSame('$2y$13$hashedpassword', $user->password()->toString());
+        self::assertContains(Role::USER, $user->roles());
+    }
+
+    public function testCreateUserWithSpecificRoles(): void
+    {
+        // Arrange
+        $uuid = ResourceUuid::generate();
+        $email = EmailField::fromString('admin@example.com');
+        $password = HashedPassword::fromHash('$2y$13$hashedpassword');
+        $roles = [Role::ADMIN];
+
+        // Act
+        $user = User::create($uuid, $email, $password, $roles);
+
+        // Assert
+        self::assertContains(Role::ADMIN, $user->roles());
+        self::assertContains(Role::USER, $user->roles(), 'ROLE_USER always added');
+    }
+
+    public function testRolesAreNormalizedToUniqueValues(): void
+    {
+        // Arrange
+        $uuid = ResourceUuid::generate();
+        $email = EmailField::fromString('test@example.com');
+        $password = HashedPassword::fromHash('$2y$13$hashedpassword');
+        $roles = [Role::USER, Role::USER, Role::ADMIN];
+
+        // Act
+        $user = User::create($uuid, $email, $password, $roles);
+
+        // Assert
+        self::assertCount(2, $user->roles(), 'Roles should be unique');
+        self::assertContains(Role::USER, $user->roles());
+        self::assertContains(Role::ADMIN, $user->roles());
+    }
+
+    public function testReconstituteUser(): void
+    {
+        // Arrange
+        $uuid = ResourceUuid::generate();
+        $email = EmailField::fromString('user@example.com');
+        $password = HashedPassword::fromHash('$2y$13$hashedpassword');
+        $roles = [Role::USER, Role::ADMIN];
+        $createdAt = new \DateTimeImmutable('2025-01-01 09:00:00');
+        $updatedAt = new \DateTimeImmutable('2025-01-10 14:30:00');
+
+        // Act
+        $user = User::reconstitute($uuid, $email, $password, $roles, $createdAt, $updatedAt);
+
+        // Assert
+        self::assertSame($uuid->toString(), $user->uuid()->toString());
+        self::assertEquals($createdAt, $user->createdAt());
+        self::assertEquals($updatedAt, $user->updatedAt());
+    }
+
+    public function testReconstituteWithEmptyRolesAddsDefaultRole(): void
+    {
+        // Arrange
+        $uuid = ResourceUuid::generate();
+        $email = EmailField::fromString('user@example.com');
+        $password = HashedPassword::fromHash('$2y$13$hashedpassword');
+        $roles = []; // Empty roles from DB
+        $createdAt = new \DateTimeImmutable('2025-01-01 09:00:00');
+        $updatedAt = new \DateTimeImmutable('2025-01-10 14:30:00');
+
+        // Act
+        $user = User::reconstitute($uuid, $email, $password, $roles, $createdAt, $updatedAt);
+
+        // Assert
+        self::assertContains(Role::USER, $user->roles(), 'ROLE_USER should be added automatically.');
+        self::assertCount(1, $user->roles());
+    }
+
+    public function testHasRoleReturnsTrueWhenUserHasRole(): void
+    {
+        // Arrange
+        $user = UserDataBuilder::aUser()->asAdmin()->build();
+
+        // Act & Assert
+        self::assertTrue($user->hasRole(Role::ADMIN));
+        self::assertTrue($user->hasRole(Role::USER));
+    }
+
+    public function testHasRoleReturnsFalseWhenUserDoesNotHaveRole(): void
+    {
+        // Arrange
+        $user = UserDataBuilder::aUser()->build();
+
+        // Act & Assert
+        self::assertFalse($user->hasRole(Role::ADMIN));
+    }
+
+    public function testIsAdminReturnsTrueForAdmin(): void
+    {
+        // Arrange
+        $user = UserDataBuilder::aUser()->asAdmin()->build();
+
+        // Act & Assert
+        self::assertTrue($user->isAdmin());
+    }
+
+    public function testIsAdminReturnsFalseForRegularUser(): void
+    {
+        // Arrange
+        $user = UserDataBuilder::aUser()->build();
+
+        // Act & Assert
+        self::assertFalse($user->isAdmin());
+    }
+
+    public function testChangeEmailUpdatesEmailAndUpdatedAt(): void
+    {
+        // Arrange
+        $initialTime = new \DateTimeImmutable('2025-01-01 10:00:00');
+        $updateTime = new \DateTimeImmutable('2025-01-15 14:30:00');
+
+        ClockFactory::initialize(new FrozenClock($initialTime));
+        $user = UserDataBuilder::aUser()
+            ->withEmail('old@example.com')
+            ->withUpdatedAt($initialTime)
+            ->build()
+        ;
+
+        ClockFactory::initialize(new FrozenClock($updateTime));
+        $newEmail = EmailField::fromString('new@example.com');
+
+        // Act
+        $user->changeEmail($newEmail);
+
+        // Assert
+        self::assertSame('new@example.com', $user->email()->toString());
+        self::assertEquals($updateTime, $user->updatedAt());
+    }
+
+    public function testChangePasswordUpdatesPasswordAndUpdatedAt(): void
+    {
+        // Arrange
+        $initialTime = new \DateTimeImmutable('2025-01-01 10:00:00');
+        $updateTime = new \DateTimeImmutable('2025-01-15 14:30:00');
+
+        ClockFactory::initialize(new FrozenClock($initialTime));
+        $user = UserDataBuilder::aUser()
+            ->withPassword('$2y$13$oldhash')
+            ->withUpdatedAt($initialTime)
+            ->build()
+        ;
+
+        ClockFactory::initialize(new FrozenClock($updateTime));
+        $newPassword = HashedPassword::fromHash('$2y$13$newhash');
+
+        // Act
+        $user->changePassword($newPassword);
+
+        // Assert
+        self::assertSame('$2y$13$newhash', $user->password()->toString());
+        self::assertEquals($updateTime, $user->updatedAt());
+    }
+
+    public function testUpdateRolesNormalizesAndUpdatesTimestamp(): void
+    {
+        // Arrange
+        $initialTime = new \DateTimeImmutable('2025-01-01 10:00:00');
+        $updateTime = new \DateTimeImmutable('2025-01-15 14:30:00');
+
+        ClockFactory::initialize(new FrozenClock($initialTime));
+        $user = UserDataBuilder::aUser()
+            ->withRoles([Role::USER])
+            ->withUpdatedAt($initialTime)
+            ->build()
+        ;
+
+        ClockFactory::initialize(new FrozenClock($updateTime));
+
+        // Act
+        $user->updateRoles([Role::ADMIN, Role::INVENTORY_MANAGER]);
+
+        // Assert
+        self::assertContains(Role::ADMIN, $user->roles());
+        self::assertContains(Role::INVENTORY_MANAGER, $user->roles());
+        self::assertContains(Role::USER, $user->roles(), 'Always present');
+        self::assertEquals($updateTime, $user->updatedAt());
+    }
+}

--- a/src/Auth/Tests/Entities/VO/HashedPasswordTest.php
+++ b/src/Auth/Tests/Entities/VO/HashedPasswordTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Tests package.
+ *
+ * (c) Dev-Int Création <info@developpement-interessant.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Auth\Tests\Entities\VO;
+
+use Auth\Entities\Exception\InvalidHashedPassword;
+use Auth\Entities\VO\HashedPassword;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group unitTest
+ *
+ * @covers \Auth\Entities\VO\HashedPassword
+ */
+final class HashedPasswordTest extends TestCase
+{
+    public function testFromHashCreatesInstance(): void
+    {
+        // Arrange
+        $hash = '$2y$13$somehashedpassword';
+
+        // Act
+        $password = HashedPassword::fromHash($hash);
+
+        // Assert
+        self::assertSame($hash, $password->toString());
+    }
+
+    public function testToStringReturnsHash(): void
+    {
+        // Arrange
+        $hash = '$2y$13$anotherhash';
+        $password = HashedPassword::fromHash($hash);
+
+        // Act
+        $result = $password->toString();
+
+        // Assert
+        self::assertSame($hash, $result);
+    }
+
+    public function testEqualsReturnsTrueForSameHash(): void
+    {
+        // Arrange
+        $hash = '$2y$13$samehash';
+        $password1 = HashedPassword::fromHash($hash);
+        $password2 = HashedPassword::fromHash($hash);
+
+        // Act & Assert
+        self::assertTrue($password1->equals($password2));
+    }
+
+    public function testEqualsReturnsFalseForDifferentHash(): void
+    {
+        // Arrange
+        $password1 = HashedPassword::fromHash('$2y$13$hash1');
+        $password2 = HashedPassword::fromHash('$2y$13$hash2');
+
+        // Act & Assert
+        self::assertFalse($password1->equals($password2));
+    }
+
+    public function testFromHashThrowsExceptionForEmptyString(): void
+    {
+        $this->expectException(InvalidHashedPassword::class);
+
+        HashedPassword::fromHash('');
+    }
+
+    public function testFromHashThrowsExceptionForInvalidFormat(): void
+    {
+        $this->expectException(InvalidHashedPassword::class);
+
+        HashedPassword::fromHash('plaintext-not-a-hash');
+    }
+
+    public function testFromHashAcceptsBcryptFormat(): void
+    {
+        // Arrange
+        $hash = '$2y$13$validbcrypthash';
+
+        // Act
+        $password = HashedPassword::fromHash($hash);
+
+        // Assert - no exception thrown, hash stored correctly
+        self::assertSame($hash, $password->toString());
+    }
+
+    public function testFromHashAcceptsArgon2Format(): void
+    {
+        // Arrange
+        $hash = '$argon2id$v=19$m=65536,t=4,p=1$hash';
+
+        // Act
+        $password = HashedPassword::fromHash($hash);
+
+        // Assert - no exception thrown, hash stored correctly
+        self::assertSame($hash, $password->toString());
+    }
+
+    public function testFromHashRejectsUnknownHashFormat(): void
+    {
+        // A string starting with $ but not a valid hash algorithm
+        $this->expectException(InvalidHashedPassword::class);
+
+        HashedPassword::fromHash('$invalid$notarealhash');
+    }
+}


### PR DESCRIPTION
- Initialize Auth bounded context with proper structure
- Create User domain entity with create/reconstitute factories
- Add HashedPassword value object
- Create UserRepository interface and UserNotFound exception
- Configure Deptrac rules for Auth BC layers
- Add Auth namespace to composer.json autoloading
- Add unit tests for User entity and HashedPassword VO

Closes #227